### PR TITLE
RTable exporting options

### DIFF
--- a/components/r-table/export.tsx
+++ b/components/r-table/export.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Button, Modal, Radio, Checkbox } from "antd";
+import get from "lodash.get";
 
 import RForm from "./../r-form";
 
@@ -30,7 +31,7 @@ export default class Export extends React.Component<ExportProps, ExportState> {
     formFields: {
       columnsType: "ALL",
       checkedColumnKeys: [],
-      rangeType: "ALL",
+      rangeType: get(this.props.exportOptions, "rangeTypes[0]", "ALL"),
     },
   };
 
@@ -156,7 +157,13 @@ export default class Export extends React.Component<ExportProps, ExportState> {
                       { label: locale.rangeType.selected, value: "SELECTED" },
                       { label: locale.rangeType.result, value: "RESULT" },
                       ...customizedRanges,
-                    ].filter(({ value }) => (rangeTypes as string[]).includes(value))}
+                    ]
+                      .sort(
+                        (a, b) =>
+                          (rangeTypes as string[]).findIndex((rangeType) => rangeType === a.value) -
+                          (rangeTypes as string[]).findIndex((rangeType) => rangeType === b.value)
+                      )
+                      .filter(({ value }) => (rangeTypes as string[]).includes(value))}
                   />
                 ),
               },

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "less": "2.7.2",
     "less-loader": "4.0.5",
     "merge2": "1.2.0",
+    "pre-commit": "^1.2.2",
     "prop-types": "15.5.7",
     "react": "15.6.1",
     "react-dom": "15.6.1",
@@ -64,12 +65,12 @@
     "typescript": "2.4.2",
     "webpack": "3.5.4",
     "webpack-dev-server": "2.7.1",
-    "webpack-merge": "4.1.0",
-    "pre-commit": "^1.2.2"
+    "webpack-merge": "4.1.0"
   },
   "dependencies": {
     "antd": "~2.13.1",
     "classnames": "~2.2.5",
+    "lodash.get": "^4.4.2",
     "lodash.omit": "~4.5.0"
   },
   "resolutions": {

--- a/site/_demo/r-table/index.tsx
+++ b/site/_demo/r-table/index.tsx
@@ -4,7 +4,7 @@ import { Button, Alert } from "antd";
 import { RTable } from "./../../../components";
 import "./../../../components/r-table/style";
 
-const testExport = options => {
+const testExport = (options) => {
   /* tslint:disable */
   console.clear();
   console.log(
@@ -35,6 +35,8 @@ const DemoOnly = () => (
       configModalPrev: (
         <Alert style={{ margin: "0 40px 8px" }} showIcon message="* 此处经常有 🐻 出没" />
       ),
+      rangeTypes: ["C1", "RESULT", "SELECTED", "ALL"],
+      customizedRanges: [{ label: "C1", value: "C1" }],
     }}
     onExport={testExport}
     cardTitle={<SomeActions />}
@@ -53,7 +55,7 @@ const DemoOnly = () => (
         renderTooltip: (_, { b }) => {
           return b;
         },
-        render: text => <a>{text}</a>,
+        render: (text) => <a>{text}</a>,
       },
       {
         title: "Column B",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4414,6 +4414,7 @@ lodash.foreach@^4.3.0:
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
 lodash.isarguments@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
feat: sort exporting range options by `rangeTypes`
fix: initial `rangeType`